### PR TITLE
Small refactor for WebDriverSetup and test_launch

### DIFF
--- a/DriverSetup/WebDriverSetup.py
+++ b/DriverSetup/WebDriverSetup.py
@@ -8,6 +8,9 @@ class WebDriverSetup(unittest.TestCase):
         self.driver = webdriver.Chrome(executable_path="C:/browser_drivers/chromedriver.exe")
         self.driver.implicitly_wait(10)
         self.driver.maximize_window()
+        self.driver.get("https://godaddy.com")
+        # # Will throw an error if the page doesn't load in (time)
+        self.driver.set_page_load_timeout(20)
 
     def tearDown(self):
         print("***Test environment cleanup***")

--- a/Tests/test_launch.py
+++ b/Tests/test_launch.py
@@ -9,9 +9,6 @@ class LaunchWebsite(WebDriverSetup):
 
     def test_Home_Page(self):
         driver = self.driver
-        self.driver.get("https://godaddy.com")
-        # Will throw an error if the page doesn't load in (time)
-        self.driver.set_page_load_timeout(20)
 
         web_page_title = "Domain Names, Websites, Hosting & Online Marketing Tools - GoDaddy"
 


### PR DESCRIPTION
Moved the driver.get() and driver.set_page_load_timeout() lines to WebDriverSetup.py from test_launch.py. Each test_file can now just reference WebDriverSetup.py to open the website.